### PR TITLE
Update debian.md

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -58,8 +58,10 @@ which is officially supported by Docker.
  
         $ sudo apt-get update
         $ sudo apt-get install -t wheezy-backports linux-image-amd64
+        
+2. Restart your system so Debian will use the new kernel from wheezy-backports
 
-2. Install Docker using the get.docker.com script:
+3. Install Docker using the get.docker.com script:
  
     `curl -sSL https://get.docker.com/ | sh`
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -59,7 +59,7 @@ which is officially supported by Docker.
         $ sudo apt-get update
         $ sudo apt-get install -t wheezy-backports linux-image-amd64
         
-2. Restart your system so Debian will use the new kernel from wheezy-backports
+2. Restart your system. This is necessary for Debian to use your new kernel.
 
 3. Install Docker using the get.docker.com script:
  


### PR DESCRIPTION
Debian must load the new kernel from wheezy-backports, so the user should restart the system.

Signed-off-by: Dominik Finkbeiner finkes93@gmail.com
